### PR TITLE
Add lua library imports and improve print() function

### DIFF
--- a/src/LuaWrapper.cpp
+++ b/src/LuaWrapper.cpp
@@ -18,10 +18,26 @@ extern "C" {
     delay(a);
   }
 
-  static int lua_wrapper_print(lua_State *lua) {
-    String a = String(luaL_checkstring(lua, 1));
-    Serial.println(a);
-  }
+  static int lua_wrapper_print (lua_State *L) {
+    int n = lua_gettop(L);  /* number of arguments */
+    int i;
+    lua_getglobal(L, "tostring");
+    for (i=1; i<=n; i++) {
+      const char *s;
+      size_t l;
+      lua_pushvalue(L, -1);  /* function to be called */
+      lua_pushvalue(L, i);   /* value to print */
+      lua_call(L, 1, 1);
+      s = lua_tolstring(L, -1, &l);  /* get result */
+      if (s == NULL)
+        return luaL_error(L, "'tostring' must return a string to 'print'");
+      if (i>1) Serial.write("\t");
+      Serial.write(s);
+      lua_pop(L, 1);  /* pop result */
+    }
+    Serial.println();
+    return 0;
+}
 
   static int lua_wrapper_millis(lua_State *lua) {
     lua_pushnumber(lua, (lua_Number) millis());

--- a/src/LuaWrapper.cpp
+++ b/src/LuaWrapper.cpp
@@ -34,6 +34,7 @@ LuaWrapper::LuaWrapper() {
 
   luaopen_base(_state);
   luaopen_table(_state);
+  luaopen_string(_state);
 
   lua_register(_state, "pinMode", lua_wrapper_pinMode);
   lua_register(_state, "digitalWrite", lua_wrapper_digitalWrite);

--- a/src/LuaWrapper.cpp
+++ b/src/LuaWrapper.cpp
@@ -31,6 +31,9 @@ extern "C" {
 
 LuaWrapper::LuaWrapper() {
   _state = luaL_newstate();
+
+  luaopen_base(_state);
+
   lua_register(_state, "pinMode", lua_wrapper_pinMode);
   lua_register(_state, "digitalWrite", lua_wrapper_digitalWrite);
   lua_register(_state, "delay", lua_wrapper_delay);

--- a/src/LuaWrapper.cpp
+++ b/src/LuaWrapper.cpp
@@ -35,6 +35,7 @@ LuaWrapper::LuaWrapper() {
   luaopen_base(_state);
   luaopen_table(_state);
   luaopen_string(_state);
+  luaopen_math(_state);
 
   lua_register(_state, "pinMode", lua_wrapper_pinMode);
   lua_register(_state, "digitalWrite", lua_wrapper_digitalWrite);

--- a/src/LuaWrapper.cpp
+++ b/src/LuaWrapper.cpp
@@ -33,6 +33,7 @@ LuaWrapper::LuaWrapper() {
   _state = luaL_newstate();
 
   luaopen_base(_state);
+  luaopen_table(_state);
 
   lua_register(_state, "pinMode", lua_wrapper_pinMode);
   lua_register(_state, "digitalWrite", lua_wrapper_digitalWrite);

--- a/src/lua/lmathlib.c
+++ b/src/lua/lmathlib.c
@@ -405,6 +405,7 @@ LUAMOD_API int luaopen_math (lua_State *L) {
   lua_setfield(L, -2, "maxinteger");
   lua_pushinteger(L, LUA_MININTEGER);
   lua_setfield(L, -2, "mininteger");
+  lua_setglobal(L, "math");
   return 1;
 }
 

--- a/src/lua/lstrlib.c
+++ b/src/lua/lstrlib.c
@@ -1579,6 +1579,7 @@ static void createmetatable (lua_State *L) {
 LUAMOD_API int luaopen_string (lua_State *L) {
   luaL_newlib(L, strlib);
   createmetatable(L);
+  lua_setglobal(L, "string");
   return 1;
 }
 

--- a/src/lua/ltablib.c
+++ b/src/lua/ltablib.c
@@ -256,12 +256,10 @@ typedef unsigned int IdxT;
 ** is to copy them to an array of a known type and use the array values.
 */
 static unsigned int l_randomizePivot (void) {
-  clock_t c = clock();
   time_t t = time(NULL);
-  unsigned int buff[sof(c) + sof(t)];
+  unsigned int buff[sof(t)];
   unsigned int i, rnd = 0;
-  memcpy(buff, &c, sof(c) * sizeof(unsigned int));
-  memcpy(buff + sof(c), &t, sof(t) * sizeof(unsigned int));
+  memcpy(buff, &t, sof(t) * sizeof(unsigned int));
   for (i = 0; i < sof(buff); i++)
     rnd += buff[i];
   return rnd;
@@ -440,6 +438,7 @@ static const luaL_Reg tab_funcs[] = {
 
 LUAMOD_API int luaopen_table (lua_State *L) {
   luaL_newlib(L, tab_funcs);
+  lua_setglobal(L, "table");
 #if defined(LUA_COMPAT_UNPACK)
   /* _G.unpack = table.unpack */
   lua_getfield(L, -1, "unpack");


### PR DESCRIPTION
Added import for lua standard libraries:
 - base (`tostring()`, `tonumber(), etc.)
 - math
 - table (`insert()`, `sort()`, `remove()`, ...)
 - string (`len()`, `match()`, ...)

Replaced `print()` function with the original version modified with `Serial`